### PR TITLE
Add dark/light mode toggle

### DIFF
--- a/src/main/resources/static/resources/js/theme-toggle.js
+++ b/src/main/resources/static/resources/js/theme-toggle.js
@@ -1,0 +1,51 @@
+/**
+ * Theme toggle functionality for PetClinic
+ * Toggles between light and dark mode
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  // Get theme toggle button 
+  const themeToggle = document.getElementById('theme-toggle');
+  const themeIcon = themeToggle.querySelector('span');
+  
+  // Function to toggle theme
+  function toggleTheme() {
+    const html = document.documentElement;
+    const currentTheme = html.getAttribute('data-bs-theme');
+    const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+    
+    // Update theme attribute
+    html.setAttribute('data-bs-theme', newTheme);
+    
+    // Update icon
+    updateThemeIcon(newTheme);
+    
+    // Save preference to localStorage
+    localStorage.setItem('petclinic-theme', newTheme);
+  }
+  
+  // Function to update the icon based on current theme
+  function updateThemeIcon(theme) {
+    if (theme === 'dark') {
+      // Show sun icon in dark mode
+      themeIcon.classList.remove('fa-moon-o');
+      themeIcon.classList.add('fa-sun-o');
+    } else {
+      // Show moon icon in light mode
+      themeIcon.classList.remove('fa-sun-o');
+      themeIcon.classList.add('fa-moon-o');
+    }
+  }
+  
+  // Initialize theme from localStorage or default to light
+  function initializeTheme() {
+    const savedTheme = localStorage.getItem('petclinic-theme') || 'light';
+    document.documentElement.setAttribute('data-bs-theme', savedTheme);
+    updateThemeIcon(savedTheme);
+  }
+  
+  // Add event listener to toggle button
+  themeToggle.addEventListener('click', toggleTheme);
+  
+  // Initialize theme on page load
+  initializeTheme();
+});

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html th:fragment="layout (template, menu)">
+<html th:fragment="layout (template, menu)" data-bs-theme="light">
 
 <head>
 
@@ -67,6 +67,14 @@
           </li>
 
         </ul>
+        
+        <ul class="navbar-nav ms-auto">
+          <li class="nav-item">
+            <button id="theme-toggle" class="btn btn-link nav-link" aria-label="Toggle dark mode">
+              <span class="fa fa-moon-o" aria-hidden="true"></span>
+            </button>
+          </li>
+        </ul>
       </div>
     </div>
   </nav>
@@ -88,6 +96,7 @@
   </div>
 
   <script th:src="@{/webjars/bootstrap/dist/js/bootstrap.bundle.min.js}"></script>
+  <script th:src="@{/resources/js/theme-toggle.js}"></script>
 
 </body>
 


### PR DESCRIPTION
## Summary
This PR adds a dark/light mode toggle button in the upper right corner of the navigation bar as requested in issue #1.

## Key changes:
- Added a toggle button in the navigation bar using Font Awesome icons
- Implemented JavaScript to handle toggling between light and dark modes
- Used Bootstrap's built-in theme system with CSS variables
- Persisted user preference using localStorage

## Workspace and Preview URLs
- Workspace URL: https://nicky-pike.demo.coder.com/@nicky/issue-1
- Preview app URL: https://preview--dev--issue-1--nicky--apps.dev.coder.com/
- Fixes issue: #1

🤖 Generated with [Claude Code](https://claude.ai/code)