### PR TITLE
Implement light/dark mode toggle

### DIFF
--- a/src/main/resources/static/resources/css/darkmode.css
+++ b/src/main/resources/static/resources/css/darkmode.css
@@ -1,0 +1,92 @@
+/* Dark Mode Styles */
+body.dark-mode {
+  background-color: #1a1a1a;
+  color: #e0e0e0;
+}
+
+/* Navbar */
+body.dark-mode .navbar-dark {
+  background-color: #2c2c2c !important;
+}
+
+/* Cards */
+body.dark-mode .card {
+  background-color: #2c2c2c;
+  border-color: #444;
+}
+
+/* Tables */
+body.dark-mode .table {
+  color: #e0e0e0;
+}
+
+body.dark-mode .table-striped > tbody > tr:nth-of-type(odd) {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+body.dark-mode .table-hover > tbody > tr:hover {
+  background-color: rgba(255, 255, 255, 0.075);
+}
+
+/* Forms */
+body.dark-mode .form-control,
+body.dark-mode .form-select {
+  background-color: #333;
+  border-color: #555;
+  color: #e0e0e0;
+}
+
+body.dark-mode .form-control:focus,
+body.dark-mode .form-select:focus {
+  background-color: #3a3a3a;
+  border-color: #777;
+  color: #ffffff;
+}
+
+/* Toggle button */
+#darkModeToggle {
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+  padding: 0.5rem;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+}
+
+#darkModeToggle:hover {
+  color: #fff;
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+body.dark-mode .btn-primary {
+  background-color: #0d6efd;
+  border-color: #0a58ca;
+}
+
+body.dark-mode .btn-outline-secondary {
+  color: #bbb;
+  border-color: #6c757d;
+}
+
+body.dark-mode .btn-outline-secondary:hover {
+  background-color: #5c636a;
+  color: #fff;
+}
+
+/* Links */
+body.dark-mode a {
+  color: #6ea8fe;
+}
+
+body.dark-mode a:hover {
+  color: #9ec5fe;
+}
+
+/* Page header */
+body.dark-mode .page-header {
+  border-bottom-color: #444;
+}

--- a/src/main/resources/static/resources/js/darkmode.js
+++ b/src/main/resources/static/resources/js/darkmode.js
@@ -1,0 +1,32 @@
+document.addEventListener('DOMContentLoaded', function() {
+  // Check for saved theme preference or use system preference as default
+  const isDarkMode = localStorage.getItem('darkMode') === 'true' || 
+    (localStorage.getItem('darkMode') === null && 
+     window.matchMedia('(prefers-color-scheme: dark)').matches);
+  
+  // Set initial state
+  if (isDarkMode) {
+    document.body.classList.add('dark-mode');
+  }
+  
+  // Update toggle button state
+  updateToggleButton(isDarkMode);
+  
+  // Toggle button event listener
+  document.getElementById('darkModeToggle').addEventListener('click', function() {
+    const isDark = document.body.classList.toggle('dark-mode');
+    localStorage.setItem('darkMode', isDark);
+    updateToggleButton(isDark);
+  });
+});
+
+function updateToggleButton(isDarkMode) {
+  const toggleIcon = document.getElementById('darkModeIcon');
+  if (isDarkMode) {
+    toggleIcon.classList.remove('fa-moon');
+    toggleIcon.classList.add('fa-sun');
+  } else {
+    toggleIcon.classList.remove('fa-sun');
+    toggleIcon.classList.add('fa-moon');
+  }
+}

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -19,6 +19,7 @@
 
   <link th:href="@{/webjars/font-awesome/css/font-awesome.min.css}" rel="stylesheet">
   <link rel="stylesheet" th:href="@{/resources/css/petclinic.css}" />
+  <link rel="stylesheet" th:href="@{/resources/css/darkmode.css}" />
 
 </head>
 
@@ -67,6 +68,11 @@
           </li>
 
         </ul>
+        
+        <!-- Dark mode toggle button -->
+        <button id="darkModeToggle" class="btn btn-outline-light ms-2" aria-label="Toggle dark mode">
+          <i id="darkModeIcon" class="fa fa-moon"></i>
+        </button>
       </div>
     </div>
   </nav>
@@ -88,6 +94,7 @@
   </div>
 
   <script th:src="@{/webjars/bootstrap/dist/js/bootstrap.bundle.min.js}"></script>
+  <script th:src="@{/resources/js/darkmode.js}"></script>
 
 </body>
 


### PR DESCRIPTION
## Summary
- Added a light/dark mode toggle button in the navbar
- Improved button styling and accessibility
- Implemented persistence of user preferences using localStorage
- Detects system-preferred color scheme on first load

## URLs
- Workspace URL: https://nicky-pike.demo.coder.com/@coder/issue-3
- Preview URL: https://preview--dev--issue-3--coder--apps.dev.coder.com/ 

## Test plan
- Click the toggle button to switch between light and dark modes
- Reload the page to confirm preference persists
- Test on different pages to confirm consistent behavior across site

Fixes #3