### PR TITLE
Add dark mode toggle to Spring PetClinic

### DIFF
--- a/src/main/resources/static/resources/css/dark-mode.css
+++ b/src/main/resources/static/resources/css/dark-mode.css
@@ -1,0 +1,179 @@
+/* Dark mode styles for Spring PetClinic */
+
+body.dark-mode {
+  background-color: #1a1a1a;
+  color: #f0f0f0;
+}
+
+/* Navigation bar */
+body.dark-mode .navbar-dark {
+  background-color: #333 !important;
+}
+
+/* Content containers */
+body.dark-mode .container-fluid,
+body.dark-mode .container,
+body.dark-mode .xd-container {
+  background-color: #1a1a1a;
+  color: #f0f0f0;
+}
+
+/* Tables */
+body.dark-mode table {
+  background-color: #2a2a2a;
+  color: #f0f0f0;
+}
+
+body.dark-mode .table {
+  color: #f0f0f0;
+}
+
+body.dark-mode .table-striped>tbody>tr:nth-of-type(odd) {
+  background-color: #333;
+}
+
+body.dark-mode .table-hover tbody tr:hover {
+  background-color: #444;
+}
+
+/* Cards and panels */
+body.dark-mode .card,
+body.dark-mode .panel {
+  background-color: #2a2a2a;
+  color: #f0f0f0;
+  border-color: #444;
+}
+
+body.dark-mode .card-header,
+body.dark-mode .panel-heading {
+  background-color: #333;
+  color: #f0f0f0;
+}
+
+/* Buttons */
+body.dark-mode .btn-primary {
+  background-color: #0066cc;
+  border-color: #0059b3;
+}
+
+body.dark-mode .btn-primary:hover {
+  background-color: #0059b3;
+  border-color: #004c99;
+}
+
+body.dark-mode .btn-default,
+body.dark-mode .btn-secondary {
+  background-color: #444;
+  border-color: #555;
+  color: #f0f0f0;
+}
+
+body.dark-mode .btn-default:hover,
+body.dark-mode .btn-secondary:hover {
+  background-color: #555;
+  border-color: #666;
+  color: #f0f0f0;
+}
+
+/* Forms */
+body.dark-mode input,
+body.dark-mode select,
+body.dark-mode textarea {
+  background-color: #333;
+  color: #f0f0f0;
+  border-color: #555;
+}
+
+body.dark-mode .form-control:focus {
+  background-color: #444;
+  color: #f0f0f0;
+  border-color: #0066cc;
+}
+
+/* Links */
+body.dark-mode a {
+  color: #66b3ff;
+}
+
+body.dark-mode a:hover {
+  color: #99ccff;
+}
+
+/* Dark mode toggle */
+.mode-toggle {
+  display: inline-block;
+  margin-right: 15px;
+  cursor: pointer;
+  user-select: none;
+  display: flex;
+  align-items: center;
+}
+
+.mode-toggle__text {
+  margin-right: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #fff;
+}
+
+.mode-toggle__switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+}
+
+.mode-toggle__input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.mode-toggle__slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: .4s;
+  border-radius: 34px;
+}
+
+.mode-toggle__slider:before {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  left: 3px;
+  bottom: 2px;
+  background-color: white;
+  transition: .4s;
+  border-radius: 50%;
+}
+
+body:not(.dark-mode) .mode-toggle__sun {
+  display: none;
+}
+
+body.dark-mode .mode-toggle__moon {
+  display: none;
+}
+
+.mode-toggle__input:checked + .mode-toggle__slider {
+  background-color: #2196F3;
+}
+
+.mode-toggle__input:focus + .mode-toggle__slider {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+.mode-toggle__input:checked + .mode-toggle__slider:before {
+  transform: translateX(19px);
+}
+
+.mode-toggle__icon {
+  margin-right: 5px;
+  font-size: 14px;
+}

--- a/src/main/resources/static/resources/js/dark-mode.js
+++ b/src/main/resources/static/resources/js/dark-mode.js
@@ -1,0 +1,25 @@
+// Dark mode toggle functionality for Spring PetClinic
+
+document.addEventListener('DOMContentLoaded', function() {
+  // Check for saved dark mode preference
+  const darkModeEnabled = localStorage.getItem('darkMode') === 'enabled';
+  
+  // Apply dark mode if it was previously enabled
+  if (darkModeEnabled) {
+    document.body.classList.add('dark-mode');
+    document.getElementById('dark-mode-toggle').checked = true;
+  }
+  
+  // Set up event listener for dark mode toggle
+  document.getElementById('dark-mode-toggle').addEventListener('change', function(event) {
+    if (event.target.checked) {
+      // Enable dark mode
+      document.body.classList.add('dark-mode');
+      localStorage.setItem('darkMode', 'enabled');
+    } else {
+      // Disable dark mode
+      document.body.classList.remove('dark-mode');
+      localStorage.setItem('darkMode', 'disabled');
+    }
+  });
+});

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -19,6 +19,7 @@
 
   <link th:href="@{/webjars/font-awesome/css/font-awesome.min.css}" rel="stylesheet">
   <link rel="stylesheet" th:href="@{/resources/css/petclinic.css}" />
+  <link rel="stylesheet" th:href="@{/resources/css/dark-mode.css}" />
 
 </head>
 
@@ -67,6 +68,19 @@
           </li>
 
         </ul>
+        
+        <!-- Dark Mode Toggle -->
+        <div class="mode-toggle">
+          <label class="mode-toggle__switch">
+            <span class="mode-toggle__text">
+              <i class="fa fa-sun-o mode-toggle__icon mode-toggle__sun" aria-hidden="true"></i>
+              <i class="fa fa-moon-o mode-toggle__icon mode-toggle__moon" aria-hidden="true"></i>
+              <span class="mode-toggle__label">Mode</span>
+            </span>
+            <input type="checkbox" id="dark-mode-toggle" class="mode-toggle__input">
+            <span class="mode-toggle__slider"></span>
+          </label>
+        </div>
       </div>
     </div>
   </nav>
@@ -88,6 +102,7 @@
   </div>
 
   <script th:src="@{/webjars/bootstrap/dist/js/bootstrap.bundle.min.js}"></script>
+  <script th:src="@{/resources/js/dark-mode.js}"></script>
 
 </body>
 


### PR DESCRIPTION
## Summary
- Implemented dark mode toggle in the navigation bar that clearly shows the current mode
- Added dark mode styling for all UI elements
- Persists user preference with localStorage

## Test plan
- Toggle works correctly and visually indicates current mode
- All UI elements change appearance when toggling between modes
- User preference persists between page refreshes

## Links
- Workspace URL: https://nicky-pike.demo.coder.com/@coder/issue-5-vertex
- Preview app URL: https://3000--main--issue-5-vertex--coder.nicky-pike.demo.coder.com/
- Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)