### PR TITLE
Add dark mode toggle functionality

### DIFF
--- a/src/main/resources/static/resources/css/petclinic-dark.css
+++ b/src/main/resources/static/resources/css/petclinic-dark.css
@@ -1,0 +1,123 @@
+/* Dark mode styles */
+:root.dark-mode {
+  --background-color: #1a1a1a;
+  --text-color: #f0f0f0;
+  --navbar-bg: #2c2c2c;
+  --card-bg: #2c2c2c;
+  --border-color: #444;
+  --link-color: #77b8ff;
+  --link-hover-color: #99ccff;
+  --table-stripe: #333;
+  --table-hover: #444;
+  --input-bg: #333;
+  --input-border: #555;
+  --btn-primary-bg: #0066cc;
+  --btn-primary-border: #0055aa;
+  --btn-success-bg: #2a9d5c;
+  --btn-success-border: #218a4f;
+}
+
+:root:not(.dark-mode) {
+  --background-color: #fff;
+  --text-color: #333;
+  --navbar-bg: #34302d;
+  --card-bg: #fff;
+  --border-color: #ddd;
+  --link-color: #3c8dbc;
+  --link-hover-color: #3c8dbc;
+  --table-stripe: #f9f9f9;
+  --table-hover: #f5f5f5;
+  --input-bg: #fff;
+  --input-border: #ccc;
+  --btn-primary-bg: #3c8dbc;
+  --btn-primary-border: #367fa9;
+  --btn-success-bg: #5cb85c;
+  --btn-success-border: #4cae4c;
+}
+
+/* Apply variables when dark mode is active */
+.dark-mode body {
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+.dark-mode .navbar-dark {
+  background-color: var(--navbar-bg);
+}
+
+.dark-mode .card, 
+.dark-mode .container-fluid, 
+.dark-mode .table {
+  background-color: var(--card-bg);
+  color: var(--text-color);
+  border-color: var(--border-color);
+}
+
+.dark-mode .table-striped tbody tr:nth-of-type(odd) {
+  background-color: var(--table-stripe);
+}
+
+.dark-mode .table-hover tbody tr:hover {
+  background-color: var(--table-hover);
+}
+
+.dark-mode a {
+  color: var(--link-color);
+}
+
+.dark-mode a:hover {
+  color: var(--link-hover-color);
+}
+
+.dark-mode .form-control {
+  background-color: var(--input-bg);
+  color: var(--text-color);
+  border-color: var(--input-border);
+}
+
+.dark-mode .btn-primary {
+  background-color: var(--btn-primary-bg);
+  border-color: var(--btn-primary-border);
+}
+
+.dark-mode .btn-success {
+  background-color: var(--btn-success-bg);
+  border-color: var(--btn-success-border);
+}
+
+/* Dark mode toggle styling */
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 10px;
+  margin-left: 15px;
+  cursor: pointer;
+  border-radius: 30px;
+  transition: all 0.3s ease;
+  background-color: #444;
+  position: relative;
+}
+
+.theme-toggle.dark {
+  background-color: #111;
+}
+
+.theme-toggle .toggle-icon {
+  font-size: 16px;
+  margin-right: 8px;
+}
+
+.theme-toggle .toggle-text {
+  font-size: 14px;
+  font-weight: 500;
+  color: #fff;
+}
+
+.dark-mode .table-bordered {
+  border-color: var(--border-color);
+}
+
+.dark-mode .table-bordered th,
+.dark-mode .table-bordered td {
+  border-color: var(--border-color);
+}

--- a/src/main/resources/static/resources/js/dark-mode.js
+++ b/src/main/resources/static/resources/js/dark-mode.js
@@ -1,0 +1,48 @@
+/**
+ * Dark mode functionality for PetClinic
+ */
+document.addEventListener('DOMContentLoaded', function() {
+  const root = document.documentElement;
+  const themeToggle = document.getElementById('themeToggle');
+  const toggleIcon = document.getElementById('toggleIcon');
+  const toggleText = document.getElementById('toggleText');
+  
+  // Check for saved theme preference or respect OS preference
+  const savedTheme = localStorage.getItem('theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  
+  // Apply the right theme based on saved preference or OS preference
+  if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
+    enableDarkMode();
+  } else {
+    enableLightMode();
+  }
+  
+  // Toggle theme when clicking the theme toggle
+  themeToggle.addEventListener('click', function() {
+    if (root.classList.contains('dark-mode')) {
+      enableLightMode();
+    } else {
+      enableDarkMode();
+    }
+  });
+  
+  // Functions to handle enabling/disabling dark mode
+  function enableDarkMode() {
+    root.classList.add('dark-mode');
+    themeToggle.classList.add('dark');
+    toggleIcon.classList.remove('fa-sun');
+    toggleIcon.classList.add('fa-moon');
+    toggleText.textContent = 'Dark Mode';
+    localStorage.setItem('theme', 'dark');
+  }
+  
+  function enableLightMode() {
+    root.classList.remove('dark-mode');
+    themeToggle.classList.remove('dark');
+    toggleIcon.classList.remove('fa-moon');
+    toggleIcon.classList.add('fa-sun');
+    toggleText.textContent = 'Light Mode';
+    localStorage.setItem('theme', 'light');
+  }
+});

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html th:fragment="layout (template, menu)">
+<html th:fragment="layout (template, menu)" class="">
 
 <head>
 
@@ -19,6 +19,7 @@
 
   <link th:href="@{/webjars/font-awesome/css/font-awesome.min.css}" rel="stylesheet">
   <link rel="stylesheet" th:href="@{/resources/css/petclinic.css}" />
+  <link rel="stylesheet" th:href="@{/resources/css/petclinic-dark.css}" />
 
 </head>
 
@@ -67,6 +68,12 @@
           </li>
 
         </ul>
+        
+        <!-- Dark mode toggle -->
+        <div id="themeToggle" class="theme-toggle">
+          <span id="toggleIcon" class="fa fa-sun toggle-icon"></span>
+          <span id="toggleText" class="toggle-text">Light Mode</span>
+        </div>
       </div>
     </div>
   </nav>
@@ -88,6 +95,7 @@
   </div>
 
   <script th:src="@{/webjars/bootstrap/dist/js/bootstrap.bundle.min.js}"></script>
+  <script th:src="@{/resources/js/dark-mode.js}"></script>
 
 </body>
 


### PR DESCRIPTION
## Summary
- Added dark mode toggle in the navigation bar with easy identification of current mode
- Implemented dark mode CSS theme with CSS variables for consistent styling
- Added JavaScript for toggling between modes and persistence in local storage

## Test plan
1. Navigate to the pet clinic application
2. Click the dark mode toggle in the navigation bar
3. Verify the theme changes from light to dark
4. Refresh the page and verify the theme preference is maintained
5. Test across different pages to ensure consistent styling

## Links
- Workspace: https://nicky-pike.demo.coder.com/@bearded-bytes/issue-5-vertex/
- Preview app: https://3000--main--issue-5-vertex--bearded-bytes.nicky-pike.demo.coder.com/
- Fixes: #5