### PR TITLE
Add dark mode toggle with visible mode indicator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ out/
 _site/
 *.css
 !petclinic.css
+!darkmode.css

--- a/src/main/resources/static/resources/css/darkmode.css
+++ b/src/main/resources/static/resources/css/darkmode.css
@@ -1,0 +1,55 @@
+/**
+ * Dark mode styles for Spring PetClinic
+ */
+
+/* Theme toggle button styling */
+#theme-toggle {
+  transition: all 0.3s ease;
+}
+
+#theme-toggle:hover {
+  transform: scale(1.05);
+}
+
+#current-mode-indicator {
+  font-size: 0.65em;
+  font-weight: bold;
+}
+
+/* Dark mode specific styles */
+[data-bs-theme="dark"] {
+  --bs-body-bg: #212529;
+  --bs-body-color: #f8f9fa;
+}
+
+[data-bs-theme="dark"] .navbar {
+  background-color: #343a40 !important;
+}
+
+[data-bs-theme="dark"] .container {
+  background-color: #2c3034;
+}
+
+[data-bs-theme="dark"] .table {
+  color: #e9ecef;
+}
+
+[data-bs-theme="dark"] .table-striped > tbody > tr:nth-of-type(odd) > * {
+  background-color: rgba(255, 255, 255, 0.05);
+  color: #e9ecef;
+}
+
+[data-bs-theme="dark"] .form-control {
+  background-color: #343a40;
+  color: #e9ecef;
+  border-color: #495057;
+}
+
+[data-bs-theme="dark"] .form-control:focus {
+  background-color: #3d444b;
+  color: #f8f9fa;
+}
+
+[data-bs-theme="dark"] .logo {
+  filter: brightness(0.8) contrast(1.2);
+}

--- a/src/main/resources/static/resources/js/darkmode.js
+++ b/src/main/resources/static/resources/js/darkmode.js
@@ -1,0 +1,64 @@
+/**
+ * Dark mode toggle functionality for Spring PetClinic
+ */
+document.addEventListener('DOMContentLoaded', function() {
+    // Check for saved theme preference or use the system preference
+    const getCurrentTheme = () => {
+        const savedTheme = localStorage.getItem('petclinic-theme');
+        if (savedTheme) return savedTheme;
+        
+        // If no saved preference, use system preference
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    };
+    
+    // Apply theme to document
+    const applyTheme = (theme) => {
+        document.documentElement.setAttribute('data-bs-theme', theme);
+        localStorage.setItem('petclinic-theme', theme);
+        
+        // Update toggle state
+        const toggleButton = document.getElementById('theme-toggle');
+        const themeIcon = theme === 'dark' ? 'fa-sun-o' : 'fa-moon-o';
+        const themeText = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+        const modeIndicator = theme === 'dark' ? 'Dark' : 'Light';
+        const indicatorClass = theme === 'dark' ? 'bg-dark' : 'bg-success';
+        
+        if (toggleButton) {
+            // Update the icon and text
+            const iconElement = toggleButton.querySelector('i');
+            if (iconElement) {
+                iconElement.className = `fa ${themeIcon}`;
+            }
+            
+            const labelElement = document.getElementById('theme-label');
+            if (labelElement) {
+                labelElement.textContent = themeText;
+            }
+            
+            // Update the mode indicator badge
+            const indicatorElement = document.getElementById('current-mode-indicator');
+            if (indicatorElement) {
+                indicatorElement.textContent = modeIndicator;
+                indicatorElement.className = `position-absolute top-0 start-100 translate-middle badge rounded-pill ${indicatorClass}`;
+            }
+            
+            toggleButton.setAttribute('aria-label', `Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`);
+        }
+    };
+    
+    // Toggle theme
+    const toggleTheme = () => {
+        const currentTheme = getCurrentTheme();
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        applyTheme(newTheme);
+    };
+    
+    // Initialize
+    applyTheme(getCurrentTheme());
+    
+    // Add event listener to toggle button
+    const toggleButton = document.getElementById('theme-toggle');
+    if (toggleButton) {
+        toggleButton.addEventListener('click', toggleTheme);
+    }
+});

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -19,6 +19,10 @@
 
   <link th:href="@{/webjars/font-awesome/css/font-awesome.min.css}" rel="stylesheet">
   <link rel="stylesheet" th:href="@{/resources/css/petclinic.css}" />
+  <link rel="stylesheet" th:href="@{/resources/css/darkmode.css}" />
+
+  <!-- Script for dark mode functionality -->
+  <script th:src="@{/resources/js/darkmode.js}"></script>
 
 </head>
 
@@ -67,6 +71,16 @@
           </li>
 
         </ul>
+        
+        <!-- Dark mode toggle button -->
+        <div class="navbar-nav ms-auto">
+          <button id="theme-toggle" class="btn btn-outline-light btn-sm position-relative" aria-label="Toggle dark mode">
+            <i class="fa fa-moon-o"></i> <span id="theme-label">Dark Mode</span>
+            <span id="current-mode-indicator" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-success">
+              Light
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## Description
Added a dark mode toggle that clearly indicates the current mode (light/dark) using a badge.

Changes:
- Added a visible badge to indicate which mode is currently active
- Created darkmode.css for custom dark theme styles
- Updated darkmode.js to manage the indicator badge
- Modified the toggle button to clearly show the current mode

## Workspace & Preview Information
- Workspace URL: https://nicky-pike.demo.coder.com/@nicky/issue-5
- Preview app URL: https://3000--main--issue-5--nicky.nicky-pike.demo.coder.com/
- Fixes #5