### PR TITLE
Add dark mode toggle - Fixes #9

### DIFF
--- a/src/main/resources/static/resources/css/petclinic.css
+++ b/src/main/resources/static/resources/css/petclinic.css
@@ -196,6 +196,63 @@
 *::after {
   box-sizing: border-box; }
 
+/* Dark mode toggle styles */
+.theme-toggle-wrapper {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 15px;
+}
+
+.theme-toggle {
+  display: inline-block;
+  position: relative;
+  width: 48px;
+  height: 24px;
+}
+
+.theme-toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.theme-toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: .4s;
+  border-radius: 24px;
+}
+
+.theme-toggle-slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: .4s;
+  border-radius: 50%;
+}
+
+input:checked + .theme-toggle-slider {
+  background-color: #343a40;
+}
+
+input:checked + .theme-toggle-slider:before {
+  transform: translateX(24px);
+}
+
+.theme-toggle-icon {
+  margin-right: 6px;
+  font-size: 14px;
+}
+
 @media (prefers-reduced-motion: no-preference) {
   :root {
     scroll-behavior: smooth; } }

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -31,6 +31,14 @@
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="main-navbar" style>
+        <div class="theme-toggle-wrapper ms-auto me-2">
+          <span class="theme-toggle-icon fa fa-sun-o" aria-hidden="true"></span>
+          <label class="theme-toggle">
+            <input type="checkbox" id="theme-toggle">
+            <span class="theme-toggle-slider"></span>
+          </label>
+          <span class="theme-toggle-icon fa fa-moon-o" aria-hidden="true"></span>
+        </div>
 
         <ul class="navbar-nav me-auto mb-2 mb-lg-0" th:remove="all">
 
@@ -88,7 +96,33 @@
   </div>
 
   <script th:src="@{/webjars/bootstrap/dist/js/bootstrap.bundle.min.js}"></script>
-
+  <script>
+    // Dark mode toggle functionality
+    document.addEventListener('DOMContentLoaded', function() {
+      const toggleSwitch = document.getElementById('theme-toggle');
+      
+      // Check for saved theme preference or prefer-color-scheme
+      const currentTheme = localStorage.getItem('theme') || 
+        (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      
+      // Apply the saved theme or default
+      if (currentTheme === 'dark') {
+        document.documentElement.setAttribute('data-bs-theme', 'dark');
+        toggleSwitch.checked = true;
+      }
+      
+      // Toggle theme when switch is clicked
+      toggleSwitch.addEventListener('change', function() {
+        if (this.checked) {
+          document.documentElement.setAttribute('data-bs-theme', 'dark');
+          localStorage.setItem('theme', 'dark');
+        } else {
+          document.documentElement.setAttribute('data-bs-theme', 'light');
+          localStorage.setItem('theme', 'light');
+        }
+      });
+    });
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- Added dark mode toggle switch in the navbar that allows users to switch between light and dark themes
- Theme preference is saved in localStorage so it persists between sessions
- Added CSS styles for the toggle switch with sun and moon icons

## Test plan
- Toggle between light and dark modes using the switch in the navbar
- Verify that the theme preference is saved when refreshing the page
- Verify that the appearance changes appropriately for both themes

Workspace URL: https://nicky-pike.demo.coder.com/@nicky/issue-9
Preview URL: https://3000--main--issue-9--nicky.nicky-pike.demo.coder.com/
Fixes #9

🤖 Generated with [Claude Code](https://claude.ai/code)