### PR TITLE
Add dark mode toggle with sun/moon icons

### DIFF
--- a/src/main/resources/static/resources/css/darkTheme.css
+++ b/src/main/resources/static/resources/css/darkTheme.css
@@ -98,6 +98,9 @@
     vertical-align: middle;
     margin-left: 15px;
     cursor: pointer;
+    position: absolute;
+    top: 15px;
+    right: 20px;
   }
   
   .dark-mode-toggle input {
@@ -105,7 +108,7 @@
   }
   
   .dark-mode-toggle i {
-    font-size: 1.25rem;
+    font-size: 1.5rem;
     color: #ffffff;
     transition: color 0.3s ease;
   }

--- a/src/main/resources/static/resources/css/light-dark-toggle.css
+++ b/src/main/resources/static/resources/css/light-dark-toggle.css
@@ -1,0 +1,56 @@
+/**
+ * Light/dark toggle styles for PetClinic application
+ */
+
+/* Toggle button container styles */
+.dark-mode-toggle {
+  position: absolute;
+  top: 15px;
+  right: 20px;
+  display: inline-block;
+  vertical-align: middle;
+  cursor: pointer;
+  z-index: 1000;
+}
+
+/* Hide the checkbox input */
+.dark-mode-toggle input {
+  display: none;
+}
+
+/* Icon styles for light/dark mode */
+.dark-mode-toggle i {
+  font-size: 1.5rem;
+  color: #ffffff;
+  transition: all 0.3s ease;
+}
+
+/* Hover effect on icon */
+.dark-mode-toggle:hover i {
+  transform: scale(1.1);
+}
+
+/* Light mode specific styles */
+[data-bs-theme="light"] .dark-mode-toggle i {
+  color: #495057;
+}
+
+/* Styles for toggle icon animation */
+.dark-mode-toggle i.fa-moon-o {
+  animation: fadeIn 0.3s ease forwards;
+}
+
+.dark-mode-toggle i.fa-sun-o {
+  animation: fadeIn 0.3s ease forwards;
+}
+
+@keyframes fadeIn {
+  0% {
+    opacity: 0.5;
+    transform: scale(0.9);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/src/main/resources/static/resources/js/darkMode.js
+++ b/src/main/resources/static/resources/js/darkMode.js
@@ -8,8 +8,19 @@ document.addEventListener('DOMContentLoaded', function() {
     // Check if user previously selected dark mode
     const isDarkMode = localStorage.getItem('darkMode') === 'true';
     
-    // Set initial state
-    if (isDarkMode) {
+    // Set initial state based on system preference if no preference was saved
+    if (localStorage.getItem('darkMode') === null) {
+        const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (prefersDarkMode) {
+            document.documentElement.setAttribute('data-bs-theme', 'dark');
+            if (darkModeToggle) {
+                darkModeToggle.checked = true;
+                updateDarkModeIcon(true);
+            }
+            localStorage.setItem('darkMode', 'true');
+        }
+    } else if (isDarkMode) {
+        // Apply saved preference if available
         document.documentElement.setAttribute('data-bs-theme', 'dark');
         if (darkModeToggle) {
             darkModeToggle.checked = true;

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -20,6 +20,7 @@
   <link th:href="@{/webjars/font-awesome/css/font-awesome.min.css}" rel="stylesheet">
   <link rel="stylesheet" th:href="@{/resources/css/petclinic.css}" />
   <link rel="stylesheet" th:href="@{/resources/css/darkTheme.css}" />
+  <link rel="stylesheet" th:href="@{/resources/css/light-dark-toggle.css}" />
 
 </head>
 


### PR DESCRIPTION
## Summary
- Positioned dark mode toggle in upper right corner
- Added sun/moon icons with proper mode indicators
- Enhanced toggle styling with animations
- Added system preference detection

## Workspace URL
https://issue-14--nicky.nicky-pike.demo.coder.com

## Preview App URL
https://8080--main--issue-14--nicky.nicky-pike.demo.coder.com

Fixes #14

🤖 Generated with [Claude Code](https://claude.ai/code)