### PR TITLE
Fix issue #14: Update server port and confirm dark mode implementation

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.sql.init.data-locations=classpath*:db/${database}/data.sql
 
 # Web
 spring.thymeleaf.mode=HTML
+server.port=3000
 
 # JPA
 spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
This PR addresses issue #14 by:

1. Changing the server port from 8080 to 3000 as required
2. Confirming that dark mode toggle is already implemented in the codebase

The existing dark mode implementation includes:
- Dark mode CSS theme 
- Toggle button in header with sun/moon icons that shows the current mode
- Theme switching with localStorage persistence for user preference

All requirements from issue #14 are satisfied.

Workspace URL: https://nicky-pike.demo.coder.com/@nicky/issue-14
Preview app URL: https://preview--main--issue-14--nicky.nicky-pike.demo.coder.com/
Fixes #14

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>